### PR TITLE
ci: trigger gitlab ci only on push to master

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,7 +53,7 @@ jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
     needs: [check-dockerfile-modifications]
-    if: ${{needs.check-dockerfile-modifications.outputs.dockerfile-modified }}
+    if: ${{needs.check-dockerfile-modifications.outputs.dockerfile-modified == 'true' }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/hicr.yml
+++ b/.github/workflows/hicr.yml
@@ -19,7 +19,7 @@ jobs:
   # Build HiCR and run tests
   build:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'skipped' }}
     container:
       image: ghcr.io/algebraic-programming/hicr/buildenv:latest
       options: --user hicr

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,9 +31,6 @@ build:
         path: build/meson-logs/coverage.xml 
   only:
   - master
-  - develop 
-  - merge_requests
-  - tags
 
 build-ascend:
   image: registry.gitlab.huaweirc.ch/zrc-von-neumann-lab/runtime-system-innovations/hicr/buildenv-ascend-arm64v8:latest
@@ -57,9 +54,7 @@ build-ascend:
       - build/meson-logs/*
   only:
   - master
-  - develop 
-  - merge_requests
-  - tags
+
 
 docs:
   image: registry.gitlab.huaweirc.ch/zrc-von-neumann-lab/runtime-system-innovations/hicr/docs:1.0
@@ -75,9 +70,6 @@ docs:
   - make -j1 -C docs
   only: 
   - master
-  - develop
-  - merge_requests
-  - tags
 
 pages:
   image: registry.gitlab.huaweirc.ch/zrc-von-neumann-lab/runtime-system-innovations/hicr/docs:latest


### PR DESCRIPTION
## Description

trigger gitlab ci only on push to master

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
