### PR TITLE
ci: enable write permissions from forks

### DIFF
--- a/.github/workflows/pr-development.yml
+++ b/.github/workflows/pr-development.yml
@@ -3,7 +3,7 @@ name: PR development - Build and Run Tests
 # if statements modified to avoid: https://stackoverflow.com/questions/69354003/github-action-job-fire-when-previous-job-skipped
 
 on:
-  pull_request:
+  pull_request_target:
     branches: ["master"]
 
 permissions:


### PR DESCRIPTION
## Description

- change the PR triggering event to `pull_request_target` in order to inherit the access token with read write permissions. This way, the code coverage action can work with PR from forked repositories. 

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
There is no way to test this other than merge into master and see if it works