### PR TITLE
adding the tracr reset marker

### DIFF
--- a/include/hicr/backends/nosv/executionState.hpp
+++ b/include/hicr/backends/nosv/executionState.hpp
@@ -205,6 +205,11 @@ class ExecutionState final : public HiCR::ExecutionState
     // Executing the function (Else we throw at runtime)
     if (fc) { fc(arg); }
     else { HICR_THROW_RUNTIME("Error: No valid callback function.\n"); }
+
+// TraCR reset marker to nothing as otherwise nOS-V continues displaying them.
+#ifdef ENABLE_INSTRUMENTATION
+    INSTRUMENTATION_VMARKER_RESET();
+#endif
   }
 
   /**

--- a/include/hicr/backends/nosv/meson.build
+++ b/include/hicr/backends/nosv/meson.build
@@ -1,6 +1,6 @@
 # HiCR nOS-V Backend Configuration
 
-nosvDep = dependency('nos-v', required: true, version: '3.1.0')
+nosvDep = dependency('nos-v', required: true, version: '>=3.1.0')
 
 backendIncludes = include_directories([
 ])


### PR DESCRIPTION
## Description

TraCR reset marker in nOS-V executionState at the end of the run_callback. nOS-V makes buggy traces if they are not set to None. 

## Type of change

_What type of changes does your code introduce to HiCR? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Verification
<!-- How you tested it? How do you know it works? -->
Please check the [testing guidelines](introduction/build.html#building-tests-and-examples) for recommendations about automated tests.

<!-- 
## Changelog entry

_Please put a one-line changelog entry below. This will be copied to the changelog file during the release process._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->
<!-- 
```release-note

``` --> 