### PR TITLE
ci: enable manifest push only if both docker images are built

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,8 +28,8 @@ jobs:
     needs: [ build-docker-amd64, build-docker-arm64 ]
     if: |
       always() &&
-      (contains(needs.build-docker-amd64.result, 'success') || contains(needs.build-docker-amd64.result, 'skipped')) &&
-      (contains(needs.build-docker-arm64.result, 'success') || contains(needs.build-docker-arm64.result, 'skipped')) 
+      contains(needs.build-docker-amd64.result, 'success')  &&
+      contains(needs.build-docker-arm64.result, 'success')
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -90,8 +90,8 @@ jobs:
     needs: [ build-acl-docker-amd64, build-acl-docker-arm64 ]
     if: |
       always() &&
-      (contains(needs.build-acl-docker-amd64.result, 'success') || contains(needs.build-acl-docker-amd64.result, 'skipped')) &&
-      (contains(needs.build-acl-docker-arm64.result, 'success') || contains(needs.build-acl-docker-arm64.result, 'skipped')) 
+      contains(needs.build-acl-docker-amd64.result, 'success') &&
+      contains(needs.build-acl-docker-arm64.result, 'success') 
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/pr-development-workflow.yml
+++ b/.github/workflows/pr-development-workflow.yml
@@ -269,7 +269,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup
-        run: source /home/hicr/.bashrc && meson setup build -Dbackends=hwloc,pthreads,mpi,lpf,nosv,boost,opencl -Dfrontends=channel,RPCEngine,tasking,objectStore -DbuildTests=true -DbuildExamples=true -DcompileWarningsAsErrors=true
+        run: source /home/hicr/.bashrc && meson setup build -Dbackends=hwloc,pthreads,mpi,lpf,nosv,boost,opencl,acl -Dfrontends=channel,RPCEngine,tasking,objectStore -DbuildTests=true -DbuildExamples=true -DcompileWarningsAsErrors=true
 
       - name: Compile
         run: source /home/hicr/.bashrc && meson compile -C build

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -26,5 +26,5 @@ option('compileWarningsAsErrors', type : 'boolean', value : false,
 
 ###### Backend-specific options
 option('aclPath', type : 'string', value : '',
-       description: 'Indicates home directory where the acl libraries are e.g., /usr/local/Ascend/ascend-toolkit/<acl version>/)'
+       description: 'Indicates acl home directory where the include and lib folders are'
 )


### PR DESCRIPTION
## Description

- ci: enable manifest push only if both docker images are built

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
