### PR TITLE
refactor: rpc engine

### DIFF
--- a/examples/RPCEngine/README.rst
+++ b/examples/RPCEngine/README.rst
@@ -63,7 +63,7 @@ The RPC is invoked by the root instance, the other instances listen to incoming 
  if (currentInstance->isRootInstance())
   {
     for (auto &instance : im.getInstances())
-      if (instance != currentInstance) rpcEngine.requestRPC(*instance, "Test RPC");
+      if (instance != currentInstance) rpcEngine.requestRPC(instance->getId(), "Test RPC");
   }
   else
     rpcEngine.listen();

--- a/examples/RPCEngine/source/include/RPCTest.hpp
+++ b/examples/RPCEngine/source/include/RPCTest.hpp
@@ -46,7 +46,7 @@ void RPCTestFc(HiCR::CommunicationManager            &cm,
   if (currentInstance->isRootInstance())
   {
     for (auto &instance : im.getInstances())
-      if (instance != currentInstance) rpcEngine.requestRPC(*instance, "Test RPC");
+      if (instance != currentInstance) rpcEngine.requestRPC(instance->getId(), "Test RPC");
   }
   else
     rpcEngine.listen();

--- a/examples/topology/distributed/README.rst
+++ b/examples/topology/distributed/README.rst
@@ -78,14 +78,14 @@ The Root instance requests the topology from all the other instances, merge them
 
     // Invoke RPC
     for (const auto &instance : instances)
-      if (instance->getId() != coordinator->getId()) rpcEngine.requestRPC(*instance, TOPOLOGY_RPC_NAME);
+      if (instance->getId() != coordinator->getId()) rpcEngine.requestRPC(instance->getId(), TOPOLOGY_RPC_NAME);
 
     // Getting return values from the RPCs containing each of the worker's topology
     for (const auto &instance : instances)
       if (instance == coordinator)
       {
         // Getting return value as a memory slot
-        auto returnValue = rpcEngine.getReturnValue(*instance);
+        auto returnValue = rpcEngine.getReturnValue();
 
         // Receiving raw serialized topology information from the worker
         std::string serializedTopology = (char *)returnValue->getPointer();

--- a/examples/topology/distributed/source/include/coordinator.hpp
+++ b/examples/topology/distributed/source/include/coordinator.hpp
@@ -34,14 +34,14 @@ void coordinatorFc(HiCR::frontend::RPCEngine &rpcEngine)
 
   // Printing instance information and invoking a simple RPC if its not ourselves
   for (const auto &instance : instances)
-    if (instance->getId() != coordinator->getId()) rpcEngine.requestRPC(*instance, TOPOLOGY_RPC_NAME);
+    if (instance->getId() != coordinator->getId()) rpcEngine.requestRPC(instance->getId(), TOPOLOGY_RPC_NAME);
 
   // Getting return values from the RPCs containing each of the worker's topology
   for (const auto &instance : instances)
     if (instance != coordinator)
     {
       // Getting return value as a memory slot
-      auto returnValue = rpcEngine.getReturnValue(*instance);
+      auto returnValue = rpcEngine.getReturnValue();
 
       // Receiving raw serialized topology information from the worker
       std::string serializedTopology = (char *)returnValue->getPointer();

--- a/include/hicr/core/memorySpace.hpp
+++ b/include/hicr/core/memorySpace.hpp
@@ -155,7 +155,7 @@ class MemorySpace
     _size = input[key].get<size_t>();
 
     // Deserializing usage -- do not fail if unspecified
-    key = "Usage";
+    key    = "Usage";
     _usage = 0;
     if (input.contains(key) && input[key].is_number_unsigned()) _usage = input[key].get<size_t>();
   }

--- a/include/hicr/frontends/RPCEngine/README.rst
+++ b/include/hicr/frontends/RPCEngine/README.rst
@@ -93,7 +93,7 @@ The RPC caller can then wait for the reception of the return value by specifying
     instanceManager.launchRPC(*someInstance, RPC1_TARGET_ID);
 
     // Getting return value
-    auto returnValue = *(int *)instanceManager.getReturnValue(*someInstance);
+    auto returnValue = *(int *)instanceManager.getReturnValue();
 
     // Printing return value
     printf("Obtained return value: %d\n", returnValue);

--- a/include/hicr/frontends/RPCEngine/RPCEngine.hpp
+++ b/include/hicr/frontends/RPCEngine/RPCEngine.hpp
@@ -208,14 +208,12 @@ class RPCEngine
 
   /**
    * Function to request the execution of a remote function in a remote HiCR instance
-   * \param[in] RPCName The name of the RPC to run
-   * \param[in] instance Instance on which to run the RPC
+   * \param[in] targetInstanceId Instance ID of where the rpc is to be executed
+   * \param[in] RPCName RPC Name
    * \param[in] argument An optional numerical argument to provide to the RPC
    */
-  virtual void requestRPC(HiCR::Instance &instance, const std::string &RPCName, const HiCR::frontend::RPCEngine::RPCArgument_t argument = 0)
+  virtual void requestRPC(HiCR::Instance::instanceId_t targetInstanceId, const std::string &RPCName, const HiCR::frontend::RPCEngine::RPCArgument_t argument = 0)
   {
-    const auto targetInstanceId = instance.getId();
-
     // Creating message payload
     RPCPayload_t RPCPayload;
     RPCPayload.index    = getRPCTargetIndexFromString(RPCName);
@@ -254,10 +252,9 @@ class RPCEngine
 
   /**
    * Function to get a return value from a remote instance that ran an RPC
-   * \param[in] instance Instance from which to read the return value. An RPC request should be sent to that instance before calling this function.
    * \return A pointer to a newly allocated local memory slot containing the return value
    */
-  __INLINE__ std::shared_ptr<HiCR::LocalMemorySlot> getReturnValue(HiCR::Instance &instance) const
+  __INLINE__ std::shared_ptr<HiCR::LocalMemorySlot> getReturnValue() const
   {
     // Calling the backend-specific implementation of the listen function
     while (_returnValueConsumerChannel->isEmpty());


### PR DESCRIPTION
## Description

- rpc engine requestRPC() accepts instance ids as parameter
- getReturnValue() does not take an instance argument anymore

## Type of change

- [X] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)